### PR TITLE
Use OCTGN format for importing decks into NetrunnerDB

### DIFF
--- a/www/js/Pack.js
+++ b/www/js/Pack.js
@@ -247,6 +247,55 @@ Pack.prototype = {
       textFile += card.getText(locale);
     }
     return textFile;
+  },
+
+  /**
+   * Generate the XML File of the Sealed Pack in OCTGN Format
+   */
+  generateXmlFileOctgn : function(locale) {
+    let xmlFile = "";
+
+    this.mCards.sortByCardId();
+
+    // Header
+    xmlFile += '<?xml version="1.0" encoding="utf-8" standalone="yes"?>\r\n';
+    xmlFile += '<deck game="0f38e453-26df-4c04-9d67-6d43de939c77">\r\n';
+
+    xmlFile += '<section name="Sealed Pack">\r\n';
+
+    for (const card of this.mCards.mItems) {
+      const qty = card.mNbCopies;
+      const id = card.mId;
+      const name = card.getName(locale).replace(/&/g, '&amp;').replace(/</g, '&lt;');
+      xmlFile += `<card qty="${qty}" id="bc0f047c-01b1-427f-a439-d451eda${id}">${name}</card>\r\n`;
+    }
+
+    xmlFile += '</section>\r\n';
+
+    // If the pack has no identity card, we add a neutral draft identity so that NetrunnerDB
+    // does not automatically fill in Noise or ETF instead when importing the deck.
+    let hasIdentity = false;
+    for (const card of this.mCards.mItems) {
+      if (card.hasType(CardType.IDENTITY)) {
+        hasIdentity = true;
+        break;
+      }
+    }
+
+    if (!hasIdentity) {
+      xmlFile += '<section name="Neutral Identity">\r\n';
+      if (this.mSide == Side.CORP) {
+        xmlFile += '<card qty="1" id="bc0f047c-01b1-427f-a439-d451eda00005">The Shadow: Pulling the Strings</card>\r\n';
+      } else {
+        xmlFile += '<card qty="1" id="bc0f047c-01b1-427f-a439-d451eda00006">The Masque: Cyber General</card>\r\n';
+      }
+      xmlFile += '</section>\r\n';
+    }
+
+    // Footer
+    xmlFile += '</deck>\r\n';
+
+    return xmlFile;
   }
 
 };

--- a/www/js/Sealed.js
+++ b/www/js/Sealed.js
@@ -104,7 +104,7 @@ Sealed.prototype = {
             // Generate the Sealed Pack File sorted Alphabetically
             var textFile = sealedPack.generateTextFileSortedByAlphabeticalOrder(locale);
             // Add the Text File to the ZIP file
-            var path = "Sorted by Alphabetical order (Import into NetrunnerDB or Jinteki.net)/" + locale + "/" + fileName;
+            var path = "Sorted by Alphabetical order (Import into Jinteki.net)/" + locale + "/" + fileName;
             zip.file(path, textFile);
             zip.file("Sorted by Player/" + player.mName + "/" + path, textFile);
 
@@ -128,6 +128,13 @@ Sealed.prototype = {
             var path = "Sorted by Data Pack/" + locale + "/" + fileName;
             zip.file(path, textFile);
             zip.file("Sorted by Player/" + player.mName + "/" + path, textFile);
+
+            // Generate the OCTGN XML file for importing into NetrunnerDB
+            var xmlFile = sealedPack.generateXmlFileOctgn();
+            // Add the XML File to the ZIP file
+            var path = "OCTGN Format (Import into NetrunnerDB)/" + fileName.replace(/\.txt$/, ".o8d");
+            zip.file(path, xmlFile);
+            zip.file("Sorted by Player/" + player.mName + "/" + path, xmlFile);
           }
         }
       }


### PR DESCRIPTION
First of all, thank you very much for making this tool! I hope to revive Netrunner in my local group by using this to soften or remove the deckbuilding requirements of playing Netrunner.

When importing the starter packs generated by this tool into NetrunnerDB, I was running into issues caused by having both the original Core Set and the Revised Core Set. Since some cards appear in both, it is not enough to use the card's name to uniquely identify the card. If the generator ended up giving me, e.g., 2 Datasuckers from the original Core and 1 from the Revised Core, then the alphabetical list would contain the following lines:

```
2 Datasucker
1 Datasucker
```

Importing this into NetrunnerDB will lead to the deck having only 1 Datasucker, since the quantity on the latter line would overwrite the former one.

Fortunately, NetrunnerDB supports importing from a format which uses the five-digit card ID numbers instead of card names (this format is the XML OCTGN format). By exporting the packs in this format, it is possible to losslessly import them into NetrunnerDB.

I have added this feature for my own private use but I imagined it might be useful to the general public as well.

Once more, thanks a lot for this tool! 